### PR TITLE
Modify entrypoint to better handle one-shot mode (Vs. cron mode) and …

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The following **optional** arguments allow to tweak the cleaning policy and logi
 
 - `CRON_SCHEDULE`: If defined, a built-in cron-like daemon will take care of running the the cleaning script at here-defined intervals.
 
-This is mostly meant to be used with docker-compose and an always-running cleaning job.
+This is mostly meant to be used with docker-compose and an always-running cleaning job.  
 **Do not use this if you use another way of schedulling**, like Kubernetes cronjobs for instance (since it launches "one-shot" jobs at intervals defined in the kubernetes cronjob parameters) or if you simply run it manually from time to time.
 
 A cron expression represents a set of times, using 6 space-separated fields.
@@ -37,7 +37,7 @@ For example, to clean every day at midnight sharp, set it to `0 0 0 * * *`
 - `MAILER_HOST`: SMTP server hostname.
 - `MAILER_PORT`: SMTP server port.
 - `MAILER_FROM`: `From:` email address.
-- `MAILER_TO`: `To:` email address(es). For example,  `name@provider.net,name2@provider.net`.
+- `MAILER_TO`: `To:` email address(es). For example,  `name@provider.net,name2@provider.net`.  
 If any of `MAILER_HOST`, `MAILER_PORT`, `MAILER_FROM` or `MAILER_TO` is missing, no mail will be sent and logging will only take place on the container's console.
 - `MAIL_TIMEOUT`: When run in one-shot mode (ie. CRON_SCHEDULE is **not** defined) we need to ensure that ssmtp has enough time to actually send the mail before the container shuts down. **(Defaults to 2 seconds.)**
 - `MAIL_AND_CONSOLE`: When "MAIL_\*" variables are defined, the job's output are sent by mail; set this to `0` to prevent logs from being also displayed on the container's console. **(Defaults to 1.)**

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ For example, to clean every day at midnight sharp, set it to `0 0 0 * * *`
 - `MAILER_FROM`: `From:` email address.
 - `MAILER_TO`: `To:` email address(es). For example,  `name@provider.net,name2@provider.net`.  
 If any of `MAILER_HOST`, `MAILER_PORT`, `MAILER_FROM` or `MAILER_TO` is missing, no mail will be sent and logging will only take place on the container's console.
-- `MAIL_TIMEOUT`: When run in one-shot mode (ie. CRON_SCHEDULE is **not** defined) we need to ensure that ssmtp has enough time to actually send the mail before the container shuts down. **(Defaults to 2 seconds.)**
+- `MAIL_TIMEOUT`: When run in one-shot mode (ie. CRON_SCHEDULE is **not** defined) we need to ensure that ssmtp has enough time to actually send the mail before the container shuts down. **(Defaults to 10 seconds.)**
 - `MAIL_AND_CONSOLE`: When "MAIL_\*" variables are defined, the job's output are sent by mail; set this to `0` to prevent logs from being also displayed on the container's console. **(Defaults to 1.)**
 
 

--- a/README.md
+++ b/README.md
@@ -3,10 +3,22 @@
 Simple script and related Docker container to automatically remove old corpus from an Hyphe instance.
 
 
-## Cleaner options
-The following options permit to set the clean policy :
+## Cleaner arguments
+The following **required** arguments allow for the cleaning to take place:
 
-- `CRON_SCHEDULE`: When you want start a clean. For example, to clean each day set `0 0 0 * * *`
+- `HYPHE_API_URL`: Hyphe API URL to clean. For example, `http://HYPHE_HOST/HYPHE_PATH/api/`
+- `HYPHE_MONGODB_HOST`: Mongo hostname.
+- `HYPHE_MONGO_PORT`: Mongo hostname.
+- `HYPHE_MONGO_DBNAME`: Mongo database name.
+- `HYPHE_ADMIN_PASSWORD`: Admin password if set in backend config.
+
+## Cleaner options
+The following **optional** arguments allow to tweak the cleaning policy and loging:
+
+- `CRON_SCHEDULE`: If defined, a built-in cron-like daemon will take care of running the the cleaning script at here-defined intervals.
+
+This is mostly meant to be used with docker-compose and an always-running cleaning job.
+**Do not use this if you use another way of schedulling**, like Kubernetes cronjobs for instance (since it launches "one-shot" jobs at intervals defined in the kubernetes cronjob parameters) or if you simply run it manually from time to time.
 
 A cron expression represents a set of times, using 6 space-separated fields.
 
@@ -19,16 +31,16 @@ Day of month | Yes        | 1-31            | * / , - ?
 Month        | Yes        | 1-12 or JAN-DEC | * / , -
 Day of week  | Yes        | 0-6 or SUN-SAT  | * / , - ?
 
-- `HYPHE_API_URL`: Hyphe API URL to clean. For example, `http://HYPHE_HOST/HYPHE_PATH/api/`
-- `HYPHE_MONGODB_HOST`: Mongo hostname.
-- `HYPHE_MONGO_PORT`: Mongo hostname.
-- `HYPHE_MONGO_DBNAME`: Mongo database name.
-- `HYPHE_ADMIN_PASSWORD`: Admin password if set in backend config.
-- `DAYSBACK`: Days to keep.
+For example, to clean every day at midnight sharp, set it to `0 0 0 * * *`
+
+- `DAYSBACK`: Days to keep. **(Defaults to 7.)**
 - `MAILER_HOST`: SMTP server hostname.
 - `MAILER_PORT`: SMTP server port.
 - `MAILER_FROM`: `From:` email address.
 - `MAILER_TO`: `To:` email address(es). For example,  `name@provider.net,name2@provider.net`.
+If any of `MAILER_HOST`, `MAILER_PORT`, `MAILER_FROM` or `MAILER_TO` is missing, no mail will be sent and logging will only take place on the container's console.
+- `MAIL_TIMEOUT`: When run in one-shot mode (ie. CRON_SCHEDULE is **not** defined) we need to ensure that ssmtp has enough time to actually send the mail before the container shuts down. **(Defaults to 2 seconds.)**
+- `MAIL_AND_CONSOLE`: When "MAIL_\*" variables are defined, the job's output are sent by mail; set this to `0` to prevent logs from being also displayed on the container's console. **(Defaults to 1.)**
 
 
 You also need to link this container to `mongo` and `backend` containers.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,23 @@
 #!/bin/sh
+SHELL="/bin/sh -c"
+CMD="/usr/local/bin/python /clean_old_corpora.py ${DAYSBACK:-7}"
+MAIL_TIMEOUT=${MAIL_TIMEOUT:-2}
+MAIL_AND_CONSOLE=${MAIL_AND_CONSOLE:-1}
+                                                                                                                     
+
 if [ ! -z "$MAILER_HOST" ] && [ ! -z "$MAILER_PORT" ] && [ ! -z "$MAILER_FROM" ] && [ ! -z "$MAILER_TO" ]; then
-	echo "root:${MAILER_FROM}:${MAILER_HOST}:${MAILER_PORT}" > /etc/ssmtp/revaliases
-	exec go-cron "${CRON_SCHEDULE}" /bin/sh -c "/usr/local/bin/python /clean_old_corpora.py ${DAYSBACK} | mail -s 'cron ${HOSTNAME}' ${MAILER_TO}"
+        echo "Configuring mail from ${MAILER_FROM} via ${MAILER_HOST}:${MAILER_PORT}"
+        echo "root:${MAILER_FROM}:${MAILER_HOST}:${MAILER_PORT}" > /etc/ssmtp/revaliases
+        MAIL_COMMAND="| mail -s \"Mail from hyphe cleaner on ${HOSTNAME}\" ${MAILER_TO}"
+	if [ -z "$CRON_SCHEDULE" ] ; then MAIL_COMMAND="$MAIL_COMMAND && sleep $MAIL_TIMEOUT" ; fi
+	if [ "$MAIL_AND_CONSOLE" != "0" ] ; then
+	        echo "Also logging to stdout as since "MAIL_AND_CONSOLE" is not set to "0""
+	        TEE="| tee /dev/stderr"
+	fi
 else
-	echo "Mailer variables not defined, logging to stdout..."
-	exec go-cron "${CRON_SCHEDULE}" /bin/sh -c "python /clean_old_corpora.py ${DAYSBACK}"
+        echo "Mailer variables not defined, logging to stdout only..."
 fi
+
+if [ ! -z "$CRON_SCHEDULE" ] ; then GOCRON="go-cron "${CRON_SCHEDULE}" " ; fi
+
+eval exec "${GOCRON}${SHELL} '${CMD} 2>&1 $TEE $MAIL_COMMAND'"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 SHELL="/bin/sh -c"
 CMD="/usr/local/bin/python /clean_old_corpora.py ${DAYSBACK:-7}"
-MAIL_TIMEOUT=${MAIL_TIMEOUT:-2}
+MAIL_TIMEOUT=${MAIL_TIMEOUT:-10}
 MAIL_AND_CONSOLE=${MAIL_AND_CONSOLE:-1}
                                                                                                                      
 
@@ -11,11 +11,11 @@ if [ ! -z "$MAILER_HOST" ] && [ ! -z "$MAILER_PORT" ] && [ ! -z "$MAILER_FROM" ]
         MAIL_COMMAND="| mail -s \"Mail from hyphe cleaner on ${HOSTNAME}\" ${MAILER_TO}"
 	if [ -z "$CRON_SCHEDULE" ] ; then MAIL_COMMAND="$MAIL_COMMAND && sleep $MAIL_TIMEOUT" ; fi
 	if [ "$MAIL_AND_CONSOLE" != "0" ] ; then
-	        echo "Also logging to stdout as since "MAIL_AND_CONSOLE" is not set to "0""
+	        echo "Also logging to console since "MAIL_AND_CONSOLE" is not set to "0""
 	        TEE="| tee /dev/stderr"
 	fi
 else
-        echo "Mailer variables not defined, logging to stdout only..."
+        echo "Mailer variables not defined, logging to console only..."
 fi
 
 if [ ! -z "$CRON_SCHEDULE" ] ; then GOCRON="go-cron "${CRON_SCHEDULE}" " ; fi


### PR DESCRIPTION
…associated readme update

The entrypoint has been reworked to allow for both the old cron mode (use the built-in go cron-like scheduller) intended for long-running containers (aka docker-compose) or a new "one-shot" mode meant to be use on the command-line, in kubernetes cronjobs or with an external schedulling tool.
A few variables have been added and the README was modified accordingly.